### PR TITLE
Refactor Store & Update provision config requests validation to use the Laravel way

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,9 +2,7 @@
 
 namespace App\Exceptions;
 
-use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
-use Throwable;
 
 class Handler extends ExceptionHandler
 {
@@ -26,31 +24,4 @@ class Handler extends ExceptionHandler
         'password',
         'password_confirmation',
     ];
-
-    /**
-     * Report or log an exception.
-     *
-     * @param  \Throwable  $exception
-     * @return void
-     *
-     * @throws \Throwable
-     */
-    public function report(Throwable $exception)
-    {
-        parent::report($exception);
-    }
-
-    /**
-     * Render an exception into an HTTP response.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Throwable  $exception
-     * @return \Symfony\Component\HttpFoundation\Response
-     *
-     * @throws \Throwable
-     */
-    public function render($request, Throwable $exception)
-    {
-        return parent::render($request, $exception);
-    }
 }

--- a/app/Factories/Rules/ProviderConfigurationRuleFactory.php
+++ b/app/Factories/Rules/ProviderConfigurationRuleFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factories\Rules;
+
+use App\Rules\ProviderConfigurationRule;
+use InvalidArgumentException;
+use Upmind\ProvisionBase\Registry\Registry;
+
+class ProviderConfigurationRuleFactory
+{
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public static function create(array $params): ProviderConfigurationRule
+    {
+        self::validate($params);
+
+        return new ProviderConfigurationRule($params['registry'], $params['category_code'], $params['provider_code']);
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    private static function validate(array $params): void
+    {
+        $required = ['registry', 'category_code', 'provider_code'];
+
+        foreach ($required as $key) {
+            if (!isset($key, $params)) {
+                throw new InvalidArgumentException('Missing required parameter: ' . $key);
+            }
+        }
+
+        if (!is_string($params['category_code'])) {
+            throw new InvalidArgumentException('Expected string for `category_code`');
+        }
+
+        if (!is_string($params['provider_code'])) {
+            throw new InvalidArgumentException('Expected string for `provider_code`');
+        }
+
+        if (!($params['registry'] instanceof Registry)) {
+            throw new InvalidArgumentException('Expected \Upmind\ProvisionBase\Registry instance for `registry`');
+        }
+    }
+}

--- a/app/Http/Controllers/Web/ProviderConfigurationDestroyController.php
+++ b/app/Http/Controllers/Web/ProviderConfigurationDestroyController.php
@@ -7,7 +7,6 @@ namespace App\Http\Controllers\Web;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\Traits\InteractsWithRegistry;
 use App\Models\ProviderConfiguration;
-use App\Services\ProviderConfigurationService;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 

--- a/app/Http/Controllers/Web/ProviderConfigurationDestroyController.php
+++ b/app/Http/Controllers/Web/ProviderConfigurationDestroyController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\Web;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\Traits\InteractsWithRegistry;
 use App\Models\ProviderConfiguration;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 
@@ -19,7 +20,7 @@ class ProviderConfigurationDestroyController extends Controller
     ) {
     }
 
-    public function __invoke(Request $request, ProviderConfiguration $configuration)
+    public function __invoke(Request $request, ProviderConfiguration $configuration): RedirectResponse
     {
         $configuration->delete();
 

--- a/app/Http/Controllers/Web/ProviderConfigurationDestroyController.php
+++ b/app/Http/Controllers/Web/ProviderConfigurationDestroyController.php
@@ -7,20 +7,27 @@ namespace App\Http\Controllers\Web;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\Traits\InteractsWithRegistry;
 use App\Models\ProviderConfiguration;
+use App\Services\ProviderConfigurationService;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Redirector;
 
 class ProviderConfigurationDestroyController extends Controller
 {
     use InteractsWithRegistry;
 
+    public function __construct(
+        private readonly Redirector $redirector
+    ) {
+    }
+
     public function __invoke(Request $request, ProviderConfiguration $configuration)
     {
         $configuration->delete();
 
-        return redirect(route('provider-show', [
+        return $this->redirector->route('provider-show', [
             'category_code' => $configuration->category_code,
             'provider_code' => $configuration->provider_code,
             'configuration_deleted' => 1
-        ]));
+        ]);
     }
 }

--- a/app/Http/Controllers/Web/ProviderConfigurationStoreController.php
+++ b/app/Http/Controllers/Web/ProviderConfigurationStoreController.php
@@ -31,8 +31,8 @@ class ProviderConfigurationStoreController extends Controller
 
         $configuration = $this->service->create(
             $provider,
-            $request->get('name'),
-            $this->undot($request->get('field_values', []))
+            $request->post('name'),
+            $this->undot($request->post('field_values', []))
         );
 
         return $this->redirector->route('provider-configuration-show', [

--- a/app/Http/Controllers/Web/ProviderConfigurationStoreController.php
+++ b/app/Http/Controllers/Web/ProviderConfigurationStoreController.php
@@ -7,10 +7,10 @@ namespace App\Http\Controllers\Web;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\Traits\InteractsWithRegistry;
 use App\Http\Controllers\Traits\TransformsArrayDot;
-use App\Http\Requests\StoreProviderConfiguration;
+use App\Http\Requests\ProviderConfigurationStoreRequest;
 use App\Services\ProviderConfigurationService;
-use Illuminate\Http\Request;
-use Illuminate\Validation\ValidationException;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Redirector;
 use Upmind\ProvisionBase\Registry\Registry;
 
 class ProviderConfigurationStoreController extends Controller
@@ -18,24 +18,26 @@ class ProviderConfigurationStoreController extends Controller
     use InteractsWithRegistry;
     use TransformsArrayDot;
 
-    public function __invoke(StoreProviderConfiguration $request, Registry $registry)
+    public function __construct(
+        private readonly ProviderConfigurationService $service,
+        private readonly Redirector $redirector
+    ) {
+    }
+
+    public function __invoke(ProviderConfigurationStoreRequest $request, Registry $registry): RedirectResponse
     {
+        /** @var \Upmind\ProvisionBase\Registry\Data\ProviderRegister $provider */
         $provider = $this->getProvider($registry, $request);
 
-        try {
-            $service = new ProviderConfigurationService();
-            $configuration = $service->create(
-                $provider,
-                $request->get('name'),
-                $this->undot($request->get('field_values', []))
-            );
-        } catch (ValidationException $e) {
-            return redirect()->back()->withErrors($e->errors());
-        }
+        $configuration = $this->service->create(
+            $provider,
+            $request->get('name'),
+            $this->undot($request->get('field_values', []))
+        );
 
-        return redirect(route('provider-configuration-show', [
+        return $this->redirector->route('provider-configuration-show', [
             'configuration' => $configuration,
             'created' => 1,
-        ]));
+        ]);
     }
 }

--- a/app/Http/Controllers/Web/ProviderConfigurationUpdateController.php
+++ b/app/Http/Controllers/Web/ProviderConfigurationUpdateController.php
@@ -7,32 +7,36 @@ namespace App\Http\Controllers\Web;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\Traits\InteractsWithRegistry;
 use App\Http\Controllers\Traits\TransformsArrayDot;
+use App\Http\Requests\ProviderConfigurationUpdateRequest;
 use App\Models\ProviderConfiguration;
 use App\Services\ProviderConfigurationService;
-use Illuminate\Http\Request;
-use Illuminate\Validation\ValidationException;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Redirector;
 
 class ProviderConfigurationUpdateController extends Controller
 {
     use InteractsWithRegistry;
     use TransformsArrayDot;
 
-    public function __invoke(Request $request, ProviderConfiguration $configuration)
-    {
-        try {
-            $service = new ProviderConfigurationService();
-            $service->update(
-                $configuration,
-                $request->get('name'),
-                $this->undot($request->get('field_values', []))
-            );
-        } catch (ValidationException $e) {
-            return redirect()->back()->withErrors($e->errors(), 'field_values');
-        }
+    public function __construct(
+        private readonly ProviderConfigurationService $service,
+        private readonly Redirector $redirector
+    ) {
+    }
 
-        return redirect(route('provider-configuration-show', [
+    public function __invoke(
+        ProviderConfigurationUpdateRequest $request,
+        ProviderConfiguration $configuration
+    ): RedirectResponse {
+        $configuration = $this->service->update(
+            $configuration,
+            $request->get('name'),
+            $this->undot($request->get('field_values', []))
+        );
+
+        return $this->redirector->route('provider-configuration-show', [
             'configuration' => $configuration,
-            'updated' => 1
-        ]));
+            'updated' => 1,
+        ]);
     }
 }

--- a/app/Http/Controllers/Web/ProviderConfigurationUpdateController.php
+++ b/app/Http/Controllers/Web/ProviderConfigurationUpdateController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Web;
 
 use App\Http\Controllers\Controller;
-use App\Http\Controllers\Traits\InteractsWithRegistry;
 use App\Http\Controllers\Traits\TransformsArrayDot;
 use App\Http\Requests\ProviderConfigurationUpdateRequest;
 use App\Models\ProviderConfiguration;
@@ -15,7 +14,6 @@ use Illuminate\Routing\Redirector;
 
 class ProviderConfigurationUpdateController extends Controller
 {
-    use InteractsWithRegistry;
     use TransformsArrayDot;
 
     public function __construct(
@@ -30,8 +28,8 @@ class ProviderConfigurationUpdateController extends Controller
     ): RedirectResponse {
         $configuration = $this->service->update(
             $configuration,
-            $request->get('name'),
-            $this->undot($request->get('field_values', []))
+            $request->post('name'),
+            $this->undot($request->post('field_values', []))
         );
 
         return $this->redirector->route('provider-configuration-show', [

--- a/app/Http/Requests/ProviderConfigurationStoreRequest.php
+++ b/app/Http/Requests/ProviderConfigurationStoreRequest.php
@@ -21,7 +21,7 @@ class ProviderConfigurationStoreRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, array<array-key, string|\Illuminate\Contracts\Validation\ValidationRule>>
+     * @return array<string, array<array-key, string|\App\Rules\ProviderConfigurationRule>>
      *
      * @throws \InvalidArgumentException
      */

--- a/app/Http/Requests/ProviderConfigurationStoreRequest.php
+++ b/app/Http/Requests/ProviderConfigurationStoreRequest.php
@@ -8,7 +8,7 @@ use App\Factories\Rules\ProviderConfigurationRuleFactory;
 use Illuminate\Foundation\Http\FormRequest;
 use Upmind\ProvisionBase\Registry\Registry;
 
-class StoreProviderConfiguration extends FormRequest
+class ProviderConfigurationStoreRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/app/Http/Requests/ProviderConfigurationUpdateRequest.php
+++ b/app/Http/Requests/ProviderConfigurationUpdateRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Factories\Rules\ProviderConfigurationRuleFactory;
+use Illuminate\Foundation\Http\FormRequest;
+use Upmind\ProvisionBase\Registry\Registry;
+
+class ProviderConfigurationUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<array-key, string|\App\Rules\ProviderConfigurationRule>>
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function rules(Registry $registry): array
+    {
+        /** @var \App\Models\ProviderConfiguration $configuration */
+        $configuration = $this->route('configuration');
+
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:255'
+            ],
+            'field_values' => [
+                'array',
+                'nullable',
+                ProviderConfigurationRuleFactory::create([
+                    'registry' => $registry,
+                    // Pass category_code and provider_code from the configuration model
+                    'category_code' => $configuration->category_code,
+                    'provider_code' => $configuration->provider_code,
+                ]),
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreProviderConfiguration.php
+++ b/app/Http/Requests/StoreProviderConfiguration.php
@@ -36,8 +36,9 @@ class StoreProviderConfiguration extends FormRequest
                 'nullable',
                 new ProviderConfigurationRule(
                     $registry,
-                    $this->route('category_code'),
-                    $this->route('provider_code')
+                    // We don't really expect these to be any other than strings.
+                    (string) $this->route('category_code'),
+                    (string) $this->route('provider_code')
                 )
             ],
         ];

--- a/app/Http/Requests/StoreProviderConfiguration.php
+++ b/app/Http/Requests/StoreProviderConfiguration.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use App\Rules\ProviderConfigurationRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Upmind\ProvisionBase\Registry\Registry;
 
 class StoreProviderConfiguration extends FormRequest
 {
@@ -21,14 +23,23 @@ class StoreProviderConfiguration extends FormRequest
      *
      * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
      */
-    public function rules(): array
+    public function rules(Registry $registry): array
     {
         return [
             'name' => [
                 'required',
                 'string',
                 'max:255'
-            ]
+            ],
+            'field_values' => [
+                'array',
+                'nullable',
+                new ProviderConfigurationRule(
+                    $registry,
+                    $this->route('category_code'),
+                    $this->route('provider_code')
+                )
+            ],
         ];
     }
 }

--- a/app/Http/Requests/StoreProviderConfiguration.php
+++ b/app/Http/Requests/StoreProviderConfiguration.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
-use App\Rules\ProviderConfigurationRule;
+use App\Factories\Rules\ProviderConfigurationRuleFactory;
 use Illuminate\Foundation\Http\FormRequest;
 use Upmind\ProvisionBase\Registry\Registry;
 
@@ -21,7 +21,9 @@ class StoreProviderConfiguration extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, array<array-key, string|\Illuminate\Contracts\Validation\ValidationRule>>
+     *
+     * @throws \InvalidArgumentException
      */
     public function rules(Registry $registry): array
     {
@@ -34,12 +36,12 @@ class StoreProviderConfiguration extends FormRequest
             'field_values' => [
                 'array',
                 'nullable',
-                new ProviderConfigurationRule(
-                    $registry,
+                ProviderConfigurationRuleFactory::create([
+                    'registry' => $registry,
                     // We don't really expect these to be any other than strings.
-                    (string) $this->route('category_code'),
-                    (string) $this->route('provider_code')
-                )
+                    'category_code' => (string) $this->route('category_code'),
+                    'provider_code' => (string) $this->route('provider_code'),
+                ]),
             ],
         ];
     }

--- a/app/Rules/ProviderConfigurationRule.php
+++ b/app/Rules/ProviderConfigurationRule.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Validation\Validator;
+use Upmind\ProvisionBase\Registry\Registry;
+
+class ProviderConfigurationRule implements ValidationRule, ValidatorAwareRule
+{
+    /**
+     * The validator instance.
+     *
+     * @var \Illuminate\Validation\Validator
+     */
+    protected Validator $validator;
+    private Registry $registry;
+    private string $categoryCode;
+    private string $providerCode;
+
+    public function __construct(Registry $registry, string $categoryCode, string $providerCode)
+    {
+        $this->registry = $registry;
+        $this->categoryCode = $categoryCode;
+        $this->providerCode = $providerCode;
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $provider = $this->registry->getProvider($this->categoryCode, $this->providerCode);
+
+        if ($provider === null) {
+            $fail(sprintf(
+                'The provision %s provider %s is not installed.',
+                $this->categoryCode,
+                $this->providerCode
+            ));
+        }
+
+        $rules = $provider->getConstructor()->getParameter()->getRules()->expand();
+
+        $this->validator->setRules($rules);
+        $this->validator->setData($value);
+
+        $this->validator->validate();
+    }
+
+    public function setValidator(Validator $validator)
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+}

--- a/app/Rules/ProviderConfigurationRule.php
+++ b/app/Rules/ProviderConfigurationRule.php
@@ -12,11 +12,6 @@ use Upmind\ProvisionBase\Registry\Registry;
 
 class ProviderConfigurationRule implements ValidationRule, ValidatorAwareRule
 {
-    /**
-     * The validator instance.
-     *
-     * @var \Illuminate\Validation\Validator
-     */
     protected Validator $validator;
     private Registry $registry;
     private string $categoryCode;
@@ -55,7 +50,7 @@ class ProviderConfigurationRule implements ValidationRule, ValidatorAwareRule
         $this->validator->validate();
     }
 
-    public function setValidator(Validator $validator)
+    public function setValidator(Validator $validator): ProviderConfigurationRule|static
     {
         $this->validator = $validator;
 

--- a/app/Services/ProviderConfigurationService.php
+++ b/app/Services/ProviderConfigurationService.php
@@ -20,8 +20,6 @@ class ProviderConfigurationService
         string $name,
         array $data
     ): ProviderConfiguration {
-        $this->validateData($provider, $data);
-
         $configuration = new ProviderConfiguration();
         $configuration->name = $name;
         $configuration->category_code = $provider->getCategory()->getIdentifier();

--- a/app/Services/ProviderConfigurationService.php
+++ b/app/Services/ProviderConfigurationService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Models\ProviderConfiguration;
-use App\Models\ProvisionRequest;
 use Upmind\ProvisionBase\Registry\Data\ProviderRegister;
 
 class ProviderConfigurationService
@@ -35,18 +34,5 @@ class ProviderConfigurationService
         $configuration->save();
 
         return $configuration;
-    }
-
-    public function delete(ProviderConfiguration $configuration)
-    {
-        $requestService = new ProvisionRequestService();
-        ProvisionRequest::where('configuration_id', $configuration->id)
-            ->chunk(20, function ($requests) use ($requestService) {
-                foreach ($requests as $request) {
-                    $requestService->delete($request);
-                }
-            });
-
-        $configuration->delete();
     }
 }

--- a/app/Services/ProviderConfigurationService.php
+++ b/app/Services/ProviderConfigurationService.php
@@ -12,8 +12,11 @@ use Upmind\ProvisionBase\Registry\Data\ProviderRegister;
 
 class ProviderConfigurationService
 {
-    public function create(ProviderRegister $provider, string $name, array $data): ProviderConfiguration
-    {
+    public function create(
+        ProviderRegister $provider,
+        string $name,
+        array $data
+    ): ProviderConfiguration {
         $configuration = new ProviderConfiguration();
         $configuration->name = $name;
         $configuration->category_code = $provider->getCategory()->getIdentifier();

--- a/app/Services/ProviderConfigurationService.php
+++ b/app/Services/ProviderConfigurationService.php
@@ -27,16 +27,11 @@ class ProviderConfigurationService
         return $configuration;
     }
 
-    /**
-     * @throws ValidationException If the given configuration data is invalid
-     */
     public function update(
         ProviderConfiguration $configuration,
         string $name,
         array $data
     ): ProviderConfiguration {
-        $this->validateData($configuration->getProvider(), $data);
-
         $configuration->name = $name;
         $configuration->data = $data;
         $configuration->save();

--- a/app/Services/ProviderConfigurationService.php
+++ b/app/Services/ProviderConfigurationService.php
@@ -12,14 +12,8 @@ use Upmind\ProvisionBase\Registry\Data\ProviderRegister;
 
 class ProviderConfigurationService
 {
-    /**
-     * @throws ValidationException If the given configuration data is invalid
-     */
-    public function create(
-        ProviderRegister $provider,
-        string $name,
-        array $data
-    ): ProviderConfiguration {
+    public function create(ProviderRegister $provider, string $name, array $data): ProviderConfiguration
+    {
         $configuration = new ProviderConfiguration();
         $configuration->name = $name;
         $configuration->category_code = $provider->getCategory()->getIdentifier();

--- a/app/Services/ProviderConfigurationService.php
+++ b/app/Services/ProviderConfigurationService.php
@@ -6,8 +6,6 @@ namespace App\Services;
 
 use App\Models\ProviderConfiguration;
 use App\Models\ProvisionRequest;
-use Illuminate\Support\Facades\Validator;
-use Illuminate\Validation\ValidationException;
 use Upmind\ProvisionBase\Registry\Data\ProviderRegister;
 
 class ProviderConfigurationService
@@ -50,15 +48,5 @@ class ProviderConfigurationService
             });
 
         $configuration->delete();
-    }
-
-    /**
-     * @throws ValidationException If the given configuration data is invalid
-     */
-    protected function validateData(ProviderRegister $provider, array $data): void
-    {
-        $rules = $provider->getConstructor()->getParameter()->getRules()->expand();
-
-        Validator::make($data, $rules)->validate();
     }
 }


### PR DESCRIPTION
Refactor to handle request validation the Laravel way
Allows for separation of concerns for request & form validations, away from services
Add Update request validation

- Add new custom rule for provider config validation and a Factory for instantiation
- Add request class validation for separation of concerns, use factory in request method for form validation
- Rename existing store form request class (validation) to match directory structure
- Refactor Store Provision configuration controller to use new logic
- Refactor Update Provision configuration controller to use new logic
- Remove redundant provision configuration service validation as no longer required
- Remove redundant provision configuration service delete method as not used in the app
- Remove redundant Error Handler methods